### PR TITLE
Criação de Process/Task/Query com sufixo

### DIFF
--- a/config/brain.php
+++ b/config/brain.php
@@ -14,4 +14,18 @@ return [
     |
     */
     'root' => app_path('Brain'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Suffix for Task, Process, and Query
+    |--------------------------------------------------------------------------
+    |
+    | When enabled (true), this setting appends a suffix to class names based
+    | on their type:
+    | - "Task" for tasks
+    | - "Process" for processes
+    | - "Query" for queries
+    |
+    */
+    'use_suffix' => true,
 ];

--- a/src/Processes/Console/MakeProcessCommand.php
+++ b/src/Processes/Console/MakeProcessCommand.php
@@ -46,7 +46,24 @@ final class MakeProcessCommand extends BaseCommand
      */
     protected function getStub(): string
     {
-        return __DIR__.'/stubs/process.stub';
+        return __DIR__ . '/stubs/process.stub';
+    }
+
+    /**
+     * Get the name input for the class.
+     *
+     * @return string The name of the class
+     */
+    #[\Override]
+    protected function getNameInput(): string
+    {
+        $name = trim($this->argument('name'));
+
+        if (config('brain.use_suffix', false) == false) {
+            return $name;
+        }
+
+        return str_ends_with($name, 'Process') ? $name : "{$name}Process";
     }
 
     /**

--- a/src/Processes/Console/MakeProcessCommand.php
+++ b/src/Processes/Console/MakeProcessCommand.php
@@ -46,7 +46,7 @@ final class MakeProcessCommand extends BaseCommand
      */
     protected function getStub(): string
     {
-        return __DIR__ . '/stubs/process.stub';
+        return __DIR__.'/stubs/process.stub';
     }
 
     /**
@@ -54,12 +54,12 @@ final class MakeProcessCommand extends BaseCommand
      *
      * @return string The name of the class
      */
-    #[\Override]
+    #[Override]
     protected function getNameInput(): string
     {
         $name = trim($this->argument('name'));
 
-        if (config('brain.use_suffix', false) == false) {
+        if (config('brain.use_suffix', false) === false) {
             return $name;
         }
 

--- a/src/Queries/Console/MakeQueryCommand.php
+++ b/src/Queries/Console/MakeQueryCommand.php
@@ -51,7 +51,24 @@ class MakeQueryCommand extends BaseCommand
      */
     protected function getStub(): string
     {
-        return __DIR__.'/stubs/query.stub';
+        return __DIR__ . '/stubs/query.stub';
+    }
+
+    /**
+     * Get the name input for the class.
+     *
+     * @return string The name of the class
+     */
+    #[\Override]
+    protected function getNameInput(): string
+    {
+        $name = trim($this->argument('name'));
+
+        if (config('brain.use_suffix', false) == false) {
+            return $name;
+        }
+
+        return str_ends_with($name, 'Query') ? $name : "{$name}Query";
     }
 
     /**

--- a/src/Queries/Console/MakeQueryCommand.php
+++ b/src/Queries/Console/MakeQueryCommand.php
@@ -51,7 +51,7 @@ class MakeQueryCommand extends BaseCommand
      */
     protected function getStub(): string
     {
-        return __DIR__ . '/stubs/query.stub';
+        return __DIR__.'/stubs/query.stub';
     }
 
     /**
@@ -59,12 +59,12 @@ class MakeQueryCommand extends BaseCommand
      *
      * @return string The name of the class
      */
-    #[\Override]
+    #[Override]
     protected function getNameInput(): string
     {
         $name = trim($this->argument('name'));
 
-        if (config('brain.use_suffix', false) == false) {
+        if (config('brain.use_suffix', false) === false) {
             return $name;
         }
 

--- a/src/Tasks/Console/MakeTaskCommand.php
+++ b/src/Tasks/Console/MakeTaskCommand.php
@@ -50,7 +50,24 @@ final class MakeTaskCommand extends BaseCommand
      */
     protected function getStub(): string
     {
-        return __DIR__.'/stubs/task.stub';
+        return __DIR__ . '/stubs/task.stub';
+    }
+
+    /**
+     * Get the name input for the class.
+     *
+     * @return string The name of the class
+     */
+    #[\Override]
+    protected function getNameInput(): string
+    {
+        $name = trim($this->argument('name'));
+
+        if (config('brain.use_suffix', false) == false) {
+            return $name;
+        }
+
+        return str_ends_with($name, 'Task') ? $name : "{$name}Task";
     }
 
     /**

--- a/src/Tasks/Console/MakeTaskCommand.php
+++ b/src/Tasks/Console/MakeTaskCommand.php
@@ -50,7 +50,7 @@ final class MakeTaskCommand extends BaseCommand
      */
     protected function getStub(): string
     {
-        return __DIR__ . '/stubs/task.stub';
+        return __DIR__.'/stubs/task.stub';
     }
 
     /**
@@ -58,12 +58,12 @@ final class MakeTaskCommand extends BaseCommand
      *
      * @return string The name of the class
      */
-    #[\Override]
+    #[Override]
     protected function getNameInput(): string
     {
         $name = trim($this->argument('name'));
 
-        if (config('brain.use_suffix', false) == false) {
+        if (config('brain.use_suffix', false) === false) {
             return $name;
         }
 

--- a/tests/Feature/Commands/MakeProcessCommandTest.php
+++ b/tests/Feature/Commands/MakeProcessCommandTest.php
@@ -50,7 +50,7 @@ test('stub should be __DIR__./stubs/process/stub', function (): void {
     $method->setAccessible(true);
     $stubPath = $method->invoke($command);
 
-    $expectedPath = realpath(__DIR__.'/../../../src/Processes/Console/stubs/process.stub');
+    $expectedPath = realpath(__DIR__ . '/../../../src/Processes/Console/stubs/process.stub');
     $actualPath = realpath($stubPath);
 
     expect($actualPath)->toBe($expectedPath);
@@ -86,4 +86,54 @@ test('get defaultNamespace with no domain', function (): void {
     $defaultNamespace = $method->invoke($command, 'App\\');
 
     expect($defaultNamespace)->toBe('App\Brain\TempDomain\Processes');
+});
+
+test('getNameInput should return the name as is when suffix is disabled', function (): void {
+    $files = app(Filesystem::class);
+    $command = new MakeProcessCommand($files);
+    $reflection = new ReflectionClass($command);
+
+    config(['brain.use_suffix' => false]);
+    $input = new TestInput(['name' => 'CreateUser']);
+    $command->setInput($input);
+
+    $method = $reflection->getMethod('getNameInput');
+    $method->setAccessible(true);
+
+    $nameInput = $method->invoke($command);
+
+    expect($nameInput)->toBe('CreateUser');
+});
+
+test('getNameInput should append Process when suffix is enabled', function (): void {
+    $files = app(Filesystem::class);
+    $command = new MakeProcessCommand($files);
+    $reflection = new ReflectionClass($command);
+
+    config(['brain.use_suffix' => true]);
+    $input = new TestInput(['name' => 'CreateUser']);
+    $command->setInput($input);
+
+    $method = $reflection->getMethod('getNameInput');
+    $method->setAccessible(true);
+
+    $nameInput = $method->invoke($command);
+
+    expect($nameInput)->toBe('CreateUserProcess');
+});
+
+test('getNameInput should not duplicate the Process suffix', function (): void {
+    $files = app(Filesystem::class);
+    $command = new MakeProcessCommand($files);
+    $reflection = new ReflectionClass($command);
+
+    config(['brain.use_suffix' => true]);
+    $input = new TestInput(['name' => 'CreateUserProcess']);
+    $command->setInput($input);
+
+    $method = $reflection->getMethod('getNameInput');
+    $method->setAccessible(true);
+
+    $nameInput = $method->invoke($command);
+    expect($nameInput)->toBe('CreateUserProcess');
 });

--- a/tests/Feature/Commands/MakeProcessCommandTest.php
+++ b/tests/Feature/Commands/MakeProcessCommandTest.php
@@ -50,7 +50,7 @@ test('stub should be __DIR__./stubs/process/stub', function (): void {
     $method->setAccessible(true);
     $stubPath = $method->invoke($command);
 
-    $expectedPath = realpath(__DIR__ . '/../../../src/Processes/Console/stubs/process.stub');
+    $expectedPath = realpath(__DIR__.'/../../../src/Processes/Console/stubs/process.stub');
     $actualPath = realpath($stubPath);
 
     expect($actualPath)->toBe($expectedPath);

--- a/tests/Feature/Commands/MakeQueryCommandTest.php
+++ b/tests/Feature/Commands/MakeQueryCommandTest.php
@@ -51,7 +51,7 @@ test('stub should be __DIR__./stubs/query/stub', function (): void {
     $method->setAccessible(true);
     $stubPath = $method->invoke($command);
 
-    $expectedPath = realpath(__DIR__.'/../../../src/Queries/Console/stubs/query.stub');
+    $expectedPath = realpath(__DIR__ . '/../../../src/Queries/Console/stubs/query.stub');
     $actualPath = realpath($stubPath);
 
     expect($actualPath)->toBe($expectedPath);
@@ -102,6 +102,56 @@ it('should replace DumyModel in the stub with the given argument model', functio
 
     $output = $method->invoke($command, 'UserQuery');
     expect($output)->toBe(
-        file_get_contents(__DIR__.'/../Fixtures/user-query.stub')
+        file_get_contents(__DIR__ . '/../Fixtures/user-query.stub')
     );
+});
+
+test('getNameInput should return the name as is when suffix is disabled', function (): void {
+    $files = app(Filesystem::class);
+    $command = new MakeQueryCommand($files);
+    $reflection = new ReflectionClass($command);
+
+    config(['brain.use_suffix' => false]);
+    $input = new TestInput(['name' => 'UserReport']);
+    $command->setInput($input);
+
+    $method = $reflection->getMethod('getNameInput');
+    $method->setAccessible(true);
+
+    $nameInput = $method->invoke($command);
+
+    expect($nameInput)->toBe('UserReport');
+});
+
+test('getNameInput should append Query when suffix is enabled', function (): void {
+    $files = app(Filesystem::class);
+    $command = new MakeQueryCommand($files);
+    $reflection = new ReflectionClass($command);
+
+    config(['brain.use_suffix' => true]);
+    $input = new TestInput(['name' => 'UserReport']);
+    $command->setInput($input);
+
+    $method = $reflection->getMethod('getNameInput');
+    $method->setAccessible(true);
+
+    $nameInput = $method->invoke($command);
+
+    expect($nameInput)->toBe('UserReportQuery');
+});
+
+test('getNameInput should not duplicate the Query suffix', function (): void {
+    $files = app(Filesystem::class);
+    $command = new MakeQueryCommand($files);
+    $reflection = new ReflectionClass($command);
+
+    config(['brain.use_suffix' => true]);
+    $input = new TestInput(['name' => 'UserReportQuery']);
+    $command->setInput($input);
+
+    $method = $reflection->getMethod('getNameInput');
+    $method->setAccessible(true);
+
+    $nameInput = $method->invoke($command);
+    expect($nameInput)->toBe('UserReportQuery');
 });

--- a/tests/Feature/Commands/MakeQueryCommandTest.php
+++ b/tests/Feature/Commands/MakeQueryCommandTest.php
@@ -51,7 +51,7 @@ test('stub should be __DIR__./stubs/query/stub', function (): void {
     $method->setAccessible(true);
     $stubPath = $method->invoke($command);
 
-    $expectedPath = realpath(__DIR__ . '/../../../src/Queries/Console/stubs/query.stub');
+    $expectedPath = realpath(__DIR__.'/../../../src/Queries/Console/stubs/query.stub');
     $actualPath = realpath($stubPath);
 
     expect($actualPath)->toBe($expectedPath);
@@ -102,7 +102,7 @@ it('should replace DumyModel in the stub with the given argument model', functio
 
     $output = $method->invoke($command, 'UserQuery');
     expect($output)->toBe(
-        file_get_contents(__DIR__ . '/../Fixtures/user-query.stub')
+        file_get_contents(__DIR__.'/../Fixtures/user-query.stub')
     );
 });
 

--- a/tests/Feature/Commands/MakeTaskCommandTest.php
+++ b/tests/Feature/Commands/MakeTaskCommandTest.php
@@ -50,7 +50,7 @@ test('stub should be __DIR__./stubs/task/stub', function (): void {
     $method->setAccessible(true);
     $stubPath = $method->invoke($command);
 
-    $expectedPath = realpath(__DIR__.'/../../../src/Tasks/Console/stubs/task.stub');
+    $expectedPath = realpath(__DIR__ . '/../../../src/Tasks/Console/stubs/task.stub');
     $actualPath = realpath($stubPath);
 
     expect($actualPath)->toBe($expectedPath);
@@ -86,4 +86,54 @@ test('get defaultNamespace with no domain', function (): void {
     $defaultNamespace = $method->invoke($command, 'App\\');
 
     expect($defaultNamespace)->toBe('App\Brain\TempDomain\Tasks');
+});
+
+test('getNameInput should return the name as is when suffix is disabled', function (): void {
+    $files = app(Filesystem::class);
+    $command = new MakeTaskCommand($files);
+    $reflection = new ReflectionClass($command);
+
+    config(['brain.use_suffix' => false]);
+    $input = new TestInput(['name' => 'CreateTenant']);
+    $command->setInput($input);
+
+    $method = $reflection->getMethod('getNameInput');
+    $method->setAccessible(true);
+
+    $nameInput = $method->invoke($command);
+
+    expect($nameInput)->toBe('CreateTenant');
+});
+
+test('getNameInput should append Query when suffix is enabled', function (): void {
+    $files = app(Filesystem::class);
+    $command = new MakeTaskCommand($files);
+    $reflection = new ReflectionClass($command);
+
+    config(['brain.use_suffix' => true]);
+    $input = new TestInput(['name' => 'CreateTenant']);
+    $command->setInput($input);
+
+    $method = $reflection->getMethod('getNameInput');
+    $method->setAccessible(true);
+
+    $nameInput = $method->invoke($command);
+
+    expect($nameInput)->toBe('CreateTenantTask');
+});
+
+test('getNameInput should not duplicate the Query suffix', function (): void {
+    $files = app(Filesystem::class);
+    $command = new MakeTaskCommand($files);
+    $reflection = new ReflectionClass($command);
+
+    config(['brain.use_suffix' => true]);
+    $input = new TestInput(['name' => 'CreateTenantTask']);
+    $command->setInput($input);
+
+    $method = $reflection->getMethod('getNameInput');
+    $method->setAccessible(true);
+
+    $nameInput = $method->invoke($command);
+    expect($nameInput)->toBe('CreateTenantTask');
 });

--- a/tests/Feature/Commands/MakeTaskCommandTest.php
+++ b/tests/Feature/Commands/MakeTaskCommandTest.php
@@ -50,7 +50,7 @@ test('stub should be __DIR__./stubs/task/stub', function (): void {
     $method->setAccessible(true);
     $stubPath = $method->invoke($command);
 
-    $expectedPath = realpath(__DIR__ . '/../../../src/Tasks/Console/stubs/task.stub');
+    $expectedPath = realpath(__DIR__.'/../../../src/Tasks/Console/stubs/task.stub');
     $actualPath = realpath($stubPath);
 
     expect($actualPath)->toBe($expectedPath);


### PR DESCRIPTION
### What:

- [ ] Bug Fix
- [X] New Feature

### Description:
Este PR adiciona uma nova funcionalidade ao pacote:

#### 1. Sufixo automático na criação de Process, Task e Query  
- Agora, ao executar `php artisan make:task CreateUser`, se a configuração `use_suffix` estiver ativada, a classe será criada como `CreateUserTask`.  O mesmo para Process e Queries.
- Se o usuário já incluir o sufixo (`CreateUserTask`), o sufixo não será duplicado. 
