### PR TITLE
Remove redundant error logging

### DIFF
--- a/src/Process.php
+++ b/src/Process.php
@@ -186,10 +186,6 @@ class Process
         } catch (Exception $e) {
             DB::rollBack();
 
-            Log::error('Error running process', [
-                'error' => $e->getMessage(),
-            ]);
-
             $this->fireEvent(Error::class, [
                 'error' => $e->getMessage(),
             ]);


### PR DESCRIPTION
### What:

- [ X ] Bug Fix
- [ ] New Feature

### Description:

This PR removes redundant error logging from the Brain package.

When an exception is thrown, the additional error log is unnecessary and leads to duplication. It can also cause issues with exception handling, such as losing control over which exceptions should or shouldn’t be reported.

// Before
<img width="976" height="95" alt="image" src="https://github.com/user-attachments/assets/8761c863-fc02-409c-8bd3-ce1035ff0d2e" />

// After
<img width="978" height="73" alt="image" src="https://github.com/user-attachments/assets/96368a04-3346-499e-9e11-e94fbc1463e0" />

