### PR TITLE
feat!: drop Laravel 11 support (EOL, unpatchable advisories)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,15 +23,13 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
         php: ["8.3", "8.4", "8.5"]
-        laravel: [ 13.*, 12.*, 11.* ]
+        laravel: [ 13.*, 12.* ]
         dependency-version: [prefer-lowest, prefer-stable]
         include:
           - laravel: 13.*
             testbench: 11.*
           - laravel: 12.*
             testbench: 10.*
-          - laravel: 11.*
-            testbench: 9.*
 
     name: Tests P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.os }}
 

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     ],
     "require": {
         "php": "^8.3.0 || ^8.4.0 || ^8.5.0",
-        "laravel/framework": "^11.37|^12.0|^13.0",
+        "laravel/framework": "^12.0|^13.0",
         "phpdocumentor/reflection": "^6.1"
     },
     "require-dev": {
@@ -27,7 +27,7 @@
         "laradumps/laradumps": "^5",
         "laravel/pint": "^1.21",
         "mockery/mockery": "^1.6.12",
-        "orchestra/testbench": "^9.0|^10.0|^11.0",
+        "orchestra/testbench": "^10.0|^11.0",
         "peckphp/peck": "^0.1.2",
         "pestphp/pest": "^3.7",
         "pestphp/pest-plugin-type-coverage": "^3.3",

--- a/docs/what-is-brain.md
+++ b/docs/what-is-brain.md
@@ -45,4 +45,4 @@ $user = GetUserByEmail::run('john@example.com');
 ## Requirements
 
 - PHP 8.3+
-- Laravel 11.37+ or 12.0+
+- Laravel 12.0+ or 13.0+


### PR DESCRIPTION
## Why

The Laravel 11 CI matrix can no longer install dependencies: Composer now refuses to resolve `laravel/framework: 11.*` because the **entire 11.x line is flagged by security advisories with no patched 11.x release** (Laravel 11 reached security EOL ~March 2026):

- `PKSA-mdq4-51ck-6kdq` — CRLF injection in the default email rule — `>=11.0.0,<12.0.0`
- `PKSA-3r5d-mb8f-1qw9`, `PKSA-m5cs-t1y6-qpcs` — also cover all of 11.x
- plus prefer-lowest-only ones (`PKSA-8qx3-n5y5-vvnd`, etc.)

The advisory set keeps growing for the EOL line, so suppressing IDs is an endless moving target. The honest fix is to drop Laravel 11.

## Changes

- `composer.json`: `laravel/framework` → `^12.0|^13.0`; `orchestra/testbench` → `^10.0|^11.0`
- `tests.yml`: remove the Laravel 11 matrix entry (L12/L13 already pass)
- `docs`: requirement bumped to Laravel 12.0+ / 13.0+

## ⚠️ Breaking change

Laravel 11 is no longer supported. Consumers on Laravel 11 must upgrade to 12 or 13.